### PR TITLE
fix: align BloodHound CE 9.1 edge schema safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ BLOODHOUND_PORT=8080
 BLOODHOUND_SCHEME=http
 ```
 
+TLS certificate verification remains enabled when no additional setting is
+provided. For a trusted lab deployment that uses a self-signed certificate,
+verification can be explicitly disabled:
+
+```env
+BLOODHOUND_VERIFY_TLS=false
+```
+
+Disabling verification weakens transport security and logs a warning. Do not
+use this option on untrusted networks.
+
 ---
 
 ## Configuration

--- a/examples/envexample
+++ b/examples/envexample
@@ -4,3 +4,5 @@ BLOODHOUND_TOKEN_KEY=
 BLOODHOUND_TOKEN_ID=
 BLOODHOUND_PORT=
 BLOODHOUND_SCHEME=
+# For trusted self-signed lab deployments only; verification is enabled by default.
+# BLOODHOUND_VERIFY_TLS=false

--- a/lib/bloodhound_api.py
+++ b/lib/bloodhound_api.py
@@ -4,6 +4,7 @@ import datetime
 import hashlib
 import hmac
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -15,6 +16,8 @@ from dotenv import load_dotenv
 # Load environment variables from .env file
 env_path = Path(__file__).resolve().parent.parent / ".env"
 load_dotenv(dotenv_path=env_path)
+
+logger = logging.getLogger(__name__)
 
 
 class BloodhoundError(Exception):
@@ -52,6 +55,7 @@ class BloodhoundBaseClient:
         token_key: str = None,
         port: int = None,
         scheme: str = None,
+        verify_tls: bool = None,
     ):
         """
         Initialize BloodHound API base client
@@ -62,6 +66,8 @@ class BloodhoundBaseClient:
             token_key: API token key
             port: API port (default: 443, or set BLOODHOUND_PORT env var)
             scheme: URL scheme (default: https, or set BLOODHOUND_SCHEME env var)
+            verify_tls: Whether to verify TLS certificates. Defaults to secure requests
+                behavior, or set BLOODHOUND_VERIFY_TLS to a supported boolean value.
         """
         # Load from parameters or environment variables
         self.scheme = scheme or os.getenv("BLOODHOUND_SCHEME") or "https"
@@ -69,6 +75,7 @@ class BloodhoundBaseClient:
         self.port = port or int(os.getenv("BLOODHOUND_PORT") or 443)
         self.token_id = token_id or os.getenv("BLOODHOUND_TOKEN_ID")
         self.token_key = token_key or os.getenv("BLOODHOUND_TOKEN_KEY")
+        self.verify_tls = self._resolve_verify_tls(verify_tls)
 
         # Validate required fields
         if not self.domain:
@@ -83,6 +90,32 @@ class BloodhoundBaseClient:
             raise BloodhoundAuthError(
                 "API token key must be provided either directly or via BLOODHOUND_TOKEN_KEY environment variable"
             )
+
+        if not self.verify_tls:
+            logger.warning(
+                "TLS certificate verification is disabled for BloodHound API requests"
+            )
+
+    @staticmethod
+    def _resolve_verify_tls(verify_tls: bool = None) -> bool:
+        """Resolve explicit TLS configuration before the environment fallback."""
+        if verify_tls is not None:
+            if not isinstance(verify_tls, bool):
+                raise TypeError("verify_tls must be a boolean or None")
+            return verify_tls
+
+        value = os.getenv("BLOODHOUND_VERIFY_TLS")
+        if value is None:
+            return True
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError(
+            "BLOODHOUND_VERIFY_TLS must be one of: "
+            "true, false, 1, 0, yes, no, on, off"
+        )
 
     def _format_url(self, uri: str) -> str:
         """Format the complete URL from the URI path"""
@@ -133,18 +166,21 @@ class BloodhoundBaseClient:
 
         # Make the request with signed headers
         try:
-            return requests.request(
-                method=method,
-                url=self._format_url(uri),
-                headers={
+            request_kwargs = {
+                "method": method,
+                "url": self._format_url(uri),
+                "headers": {
                     "User-Agent": "bloodhound-api-client 0.1",
                     "Authorization": f"bhesignature {self.token_id}",
                     "RequestDate": datetime_formatted,
                     "Signature": base64.b64encode(digester.digest()),
                     "Content-Type": content_type,
                 },
-                data=body,
-            )
+                "data": body,
+            }
+            if not self.verify_tls:
+                request_kwargs["verify"] = False
+            return requests.request(**request_kwargs)
         except requests.exceptions.ConnectionError as e:
             raise BloodhoundConnectionError(f"Failed to connect to BloodHound API: {e}")
 
@@ -325,6 +361,7 @@ class BloodhoundAPI:
         token_key: str = None,
         port: int = None,
         scheme: str = None,
+        verify_tls: bool = None,
     ):
         """
         Initialize BloodHound API client
@@ -335,12 +372,14 @@ class BloodhoundAPI:
             token_key: API token key
             port: API port 
             scheme: URL scheme
-        If domain, token_id, token_key, port or scheme are not provided, they will be loaded from
-        environment variables: BLOODHOUND_DOMAIN, BLOODHOUND_TOKEN_ID, BLOODHOUND_TOKEN_KEY, BLOODHOUND_PORT, BLOODHOUND_SCHEME
+            verify_tls: Whether to verify TLS certificates
+        If values are not provided, they will be loaded from environment variables:
+        BLOODHOUND_DOMAIN, BLOODHOUND_TOKEN_ID, BLOODHOUND_TOKEN_KEY,
+        BLOODHOUND_PORT, BLOODHOUND_SCHEME, BLOODHOUND_VERIFY_TLS.
         """
         # Initialize base client
         self.base_client = BloodhoundBaseClient(
-            domain, token_id, token_key, port, scheme
+            domain, token_id, token_key, port, scheme, verify_tls
         )
 
         # Initialize resource clients

--- a/main.py
+++ b/main.py
@@ -1421,7 +1421,8 @@ def cypher_reference() -> str:
     DCSync Edge Clarification
     -------------------------
     IMPORTANT: DCSync rights target Domain nodes, NOT Group nodes.
-    The pre-computed DCSync edge AND the raw GetChanges/GetChangesAll edges all point to Domain.
+    The pre-computed DCSync edge AND the raw GetChanges/GetChangesAll/GetChangesInFilteredSet
+    edges point to Domain.
 
     WRONG:  MATCH (n)-[:DCSync]->(g:Group)   -- returns nothing
     CORRECT: MATCH (n)-[:DCSync]->(d:Domain)
@@ -1432,6 +1433,7 @@ def cypher_reference() -> str:
 
     Note: A principal needs BOTH GetChanges AND GetChangesAll to perform DCSync.
     The pre-computed DCSync edge represents this combined condition.
+    GetChangesInFilteredSet is a separate raw edge used for SyncLAPSPassword, not DCSync.
 
     GPO Abuse Path Structure
     ------------------------
@@ -1461,7 +1463,9 @@ def cypher_reference() -> str:
     - AddSelf: Add self to group
     - DCSync: Pre-computed DCSync right (targets Domain node)
     - GetChanges / GetChangesAll: Raw replication privileges (both required for DCSync)
+    - GetChangesInFilteredSet: Raw filtered-attribute replication privilege (used for SyncLAPSPassword)
     - Owns: Object owner
+    - OwnsLimitedRights / WriteOwnerLimitedRights: Limited owner-rights variants
     - AllExtendedRights: All extended permissions
     - CanRDP / CanPSRemote / ExecuteDCOM: Remote access methods
     - AllowedToDelegate: Kerberos constrained delegation
@@ -1474,8 +1478,10 @@ def cypher_reference() -> str:
     - WriteSPN: SPN manipulation (targeted Kerberoasting)
     - WriteAccountRestrictions: Write userAccountControl / msDS-AllowedToActOnBehalfOfOtherIdentity
     - GPLink: GPO linked to OU/Container (direction: GPO -> container)
+    - SameForestTrust: Structural same-forest trust edge
+    - CrossForestTrust: Structural cross-forest trust edge
+    - SpoofSIDHistory / AbuseTGTDelegation: Traversable trust-abuse edges
     - Contains: OU/container membership
-    - TrustedBy: Domain trust
     - CoerceToTGT: Kerberos coercion to TGT
     - AddAllowedToAct: Write RBCD
     - WriteGPLink: Write GPLink attribute
@@ -1538,7 +1544,7 @@ def cypher_reference() -> str:
     RETURN u
 
     Find paths from owned principals to high-value targets:
-    MATCH p=shortestPath((s:Base)-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|GPLink|AllowedToDelegate|CoerceToTGT|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC6a|ADCSESC6b|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|SyncedToEntraUser|CoerceAndRelayNTLMToSMB|CoerceAndRelayNTLMToADCS|CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|Contains|DCFor|TrustedBy*1..]->(t:Base))
+    MATCH p=shortestPath((s:Base)-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|GPLink|AllowedToDelegate|CoerceToTGT|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC6a|ADCSESC6b|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|SyncedToADUser|CoerceAndRelayNTLMToSMB|CoerceAndRelayNTLMToADCS|WriteOwnerLimitedRights|OwnsLimitedRights|ClaimSpecialIdentity|CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|ContainsIdentity|PropagatesACEsTo|GPOAppliesTo|CanApplyGPO|HasTrustKeys|ManageCA|ManageCertificates|Contains|DCFor|SameForestTrust|SpoofSIDHistory|AbuseTGTDelegation|ProtectAdminGroups*1..]->(t:Base))
     WHERE COALESCE(s.system_tags, '') CONTAINS 'owned' AND s<>t
     RETURN p
 
@@ -1788,7 +1794,10 @@ def ad_methodology() -> str:
     MATCH p=(n)-[:HasSIDHistory]->(t) RETURN p
 
     Cross-Domain Trust Exploitation:
-    MATCH p=(d1:Domain)-[:TrustedBy]->(d2:Domain) RETURN p
+    MATCH p=(src:Domain)-[:SameForestTrust|CrossForestTrust]->(dst:Domain) RETURN p
+
+    Trust abuse edges:
+    MATCH p=(src:Domain)-[:SpoofSIDHistory|AbuseTGTDelegation]->(dst:Domain) RETURN p
     domain_info(info_type="inbound_trusts") / domain_info(info_type="outbound_trusts")
 
     NTLM Relay Paths:
@@ -2197,11 +2206,10 @@ def offensive_query_library() -> str:
     LIMIT 100
 
     All DCSync principals combined (standard + non-standard):
-    MATCH (n)-[:DCSync|GetChanges|GetChangesAll]->(d:Domain {name: 'DOMAIN.LOCAL'})
+    MATCH (n)-[r:DCSync|GetChanges|GetChangesAll]->(d:Domain {name: 'DOMAIN.LOCAL'})
     WITH n, d, collect(DISTINCT type(r)) AS edges
-    MATCH (n)-[r2:DCSync|GetChanges|GetChangesAll]->(d)
     RETURN DISTINCT n.name, labels(n) AS node_type, n.admincount,
-           COALESCE(n.system_tags, '') AS tags
+           COALESCE(n.system_tags, '') AS tags, edges
     LIMIT 100
 
     DCSync principals with group context (verify privilege level):
@@ -2209,6 +2217,11 @@ def offensive_query_library() -> str:
     OPTIONAL MATCH (n)-[:MemberOf*1..]->(g:Group)
     RETURN n.name, n.admincount, n.enabled,
            collect(DISTINCT g.name) AS group_memberships
+    LIMIT 100
+
+    Filtered attribute set replication (not DCSync):
+    MATCH (n)-[:GetChangesInFilteredSet]->(d:Domain {name: 'DOMAIN.LOCAL'})
+    RETURN n.name, labels(n) AS node_type, n.objectid
     LIMIT 100
 
     == GPO Abuse ==
@@ -2453,9 +2466,14 @@ def offensive_query_library() -> str:
     == Domain Trusts ==
 
     All outbound trusts (this domain trusts these):
-    MATCH (d:Domain)-[:TrustedBy]->(t:Domain)
-    WHERE d.name = 'DOMAIN.LOCAL'
-    RETURN d.name AS source_domain, t.name AS trusted_domain
+    MATCH p=(src:Domain)-[:SameForestTrust|CrossForestTrust]->(dst:Domain)
+    WHERE src.name = 'DOMAIN.LOCAL'
+    RETURN src.name AS source_domain, dst.name AS trusted_domain
+
+    Trust abuse edges:
+    MATCH p=(src:Domain)-[:SpoofSIDHistory|AbuseTGTDelegation]->(dst:Domain)
+    WHERE src.name = 'DOMAIN.LOCAL'
+    RETURN src.name AS source_domain, type(relationships(p)[0]) AS edge_type, dst.name AS target_domain
 
     Cross-domain attack paths via trusts:
     MATCH p=(n)-[*1..5]->(t:Group)
@@ -2508,7 +2526,7 @@ def offensive_query_library() -> str:
     == Attack Paths from Owned Nodes ==
 
     Shortest paths from all owned principals to any tier-zero/high-value targets:
-    MATCH p=shortestPath((s:Base)-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|GPLink|AllowedToDelegate|CoerceToTGT|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC6a|ADCSESC6b|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|SyncedToEntraUser|CoerceAndRelayNTLMToSMB|CoerceAndRelayNTLMToADCS|CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|Contains|DCFor|TrustedBy*1..]->(t:Base))
+    MATCH p=shortestPath((s:Base)-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|GPLink|AllowedToDelegate|CoerceToTGT|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC6a|ADCSESC6b|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|SyncedToADUser|CoerceAndRelayNTLMToSMB|CoerceAndRelayNTLMToADCS|WriteOwnerLimitedRights|OwnsLimitedRights|ClaimSpecialIdentity|CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|ContainsIdentity|PropagatesACEsTo|GPOAppliesTo|CanApplyGPO|HasTrustKeys|ManageCA|ManageCertificates|Contains|DCFor|SameForestTrust|SpoofSIDHistory|AbuseTGTDelegation|ProtectAdminGroups*1..]->(t:Base))
     WHERE COALESCE(s.system_tags, '') CONTAINS 'owned'
     AND COALESCE(t.system_tags, '') CONTAINS 'tier zero'
     AND s <> t
@@ -2523,10 +2541,11 @@ def offensive_query_library() -> str:
     All outbound edges from a specific user (effective permissions):
     MATCH (u:User {objectid: $user_objectid})-[r]->(t)
     WHERE type(r) IN ['GenericAll','GenericWrite','WriteOwner','WriteDacl',
-                      'ForceChangePassword','AddMember','Owns','AllExtendedRights',
-                      'AddKeyCredentialLink','WriteSPN','AddSelf','AdminTo',
-                      'ReadLAPSPassword','ReadGMSAPassword','DCSync','AllowedToAct',
-                      'AllowedToDelegate','AddAllowedToAct','WriteAccountRestrictions']
+                      'ForceChangePassword','AddMember','Owns','OwnsLimitedRights',
+                      'AllExtendedRights','AddKeyCredentialLink','WriteSPN','AddSelf',
+                      'AdminTo','ReadLAPSPassword','ReadGMSAPassword','DCSync',
+                      'GetChangesInFilteredSet','AllowedToAct','AllowedToDelegate',
+                      'AddAllowedToAct','WriteAccountRestrictions','WriteOwnerLimitedRights']
     RETURN t.name AS target, labels(t) AS target_type, type(r) AS permission
     LIMIT 100
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP for Connecting Claude Desktop to Bloodhound CE"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "fastmcp==2.9.2",
+    "mcp==1.9.4",
     "python-dotenv==1.1.1",
     "requests==2.32.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,9 @@ description = "MCP for Connecting Claude Desktop to Bloodhound CE"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "argparse>=1.4.0",
-    "dotenv>=0.9.9",
-    "fastmcp>=0.4.1",
-    "logging>=0.4.9.6",
-    "requests>=2.32.3",
-    "typing>=3.10.0.0",
+    "fastmcp==2.9.2",
+    "python-dotenv==1.1.1",
+    "requests==2.32.4",
 ]
 
 [dependency-groups]

--- a/tests/test_bloodhound_http.py
+++ b/tests/test_bloodhound_http.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import os
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -132,6 +134,79 @@ class TestHTTPRequestFormation:
         assert sent_data == json.dumps(cypher_query).encode("utf8")
 
         print("✅ JSON data encoding works correctly")
+
+
+class TestTLSVerification:
+    @staticmethod
+    def _response():
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"data": {}}
+        response.raise_for_status.return_value = None
+        return response
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_default_preserves_requests_call_shape(self):
+        with patch("requests.request", return_value=self._response()) as request:
+            client = BloodhoundBaseClient("host", "id", "key")
+            client.request("GET", "/api/test")
+        assert client.verify_tls is True
+        assert "verify" not in request.call_args.kwargs
+
+    @patch.dict(os.environ, {"BLOODHOUND_VERIFY_TLS": "false"}, clear=True)
+    def test_environment_can_disable_verification(self):
+        with patch("requests.request", return_value=self._response()) as request:
+            client = BloodhoundBaseClient("host", "id", "key")
+            client.request("GET", "/api/test")
+        assert client.verify_tls is False
+        assert request.call_args.kwargs["verify"] is False
+
+    @patch.dict(os.environ, {"BLOODHOUND_VERIFY_TLS": "false"}, clear=True)
+    def test_explicit_true_overrides_environment(self):
+        with patch("requests.request", return_value=self._response()) as request:
+            client = BloodhoundBaseClient("host", "id", "key", verify_tls=True)
+            client.request("GET", "/api/test")
+        assert client.verify_tls is True
+        assert "verify" not in request.call_args.kwargs
+
+    @patch.dict(os.environ, {"BLOODHOUND_VERIFY_TLS": "true"}, clear=True)
+    def test_explicit_false_overrides_environment(self):
+        client = BloodhoundBaseClient("host", "id", "key", verify_tls=False)
+        assert client.verify_tls is False
+
+    @patch.dict(os.environ, {"BLOODHOUND_VERIFY_TLS": "invalid"}, clear=True)
+    def test_invalid_environment_value_fails_closed(self):
+        with pytest.raises(ValueError, match="BLOODHOUND_VERIFY_TLS"):
+            BloodhoundBaseClient("host", "id", "key")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_invalid_constructor_value_is_rejected(self):
+        with pytest.raises(TypeError, match="verify_tls"):
+            BloodhoundBaseClient("host", "id", "key", verify_tls="false")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_disabling_verification_logs_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="lib.bloodhound_api"):
+            BloodhoundBaseClient("host", "id", "key", verify_tls=False)
+        assert "TLS certificate verification is disabled" in caplog.text
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_raw_requests_honor_disabled_verification(self):
+        with patch("requests.request", return_value=self._response()) as request:
+            client = BloodhoundBaseClient("host", "id", "key", verify_tls=False)
+            client.raw_request(
+                "POST",
+                "/api/upload",
+                body=b"raw bytes",
+                content_type="application/octet-stream",
+            )
+        assert request.call_args.kwargs["verify"] is False
+        assert request.call_args.kwargs["data"] == b"raw bytes"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_api_constructor_propagates_verification_setting(self):
+        api = BloodhoundAPI("host", "id", "key", verify_tls=False)
+        assert api.base_client.verify_tls is False
 
 
 class TestHTTPErrorHandling:

--- a/tests/test_bloodhound_http.py
+++ b/tests/test_bloodhound_http.py
@@ -66,6 +66,9 @@ class TestHTTPRequestFormation:
         assert "Signature" in headers
         assert headers["Authorization"] == "bhesignature test_token_id"
 
+        # Preserve requests' secure default and the existing call signature.
+        assert "verify" not in call_args[1]
+
         # Check that we got the expected result
         assert result == {"data": {"test": "success"}}
 

--- a/tests/test_main_mcp_tools.py
+++ b/tests/test_main_mcp_tools.py
@@ -776,6 +776,23 @@ class TestAdcsInfo:
 # ---------------------------------------------------------------------------
 
 
+class TestPromptResources:
+    def test_bloodhound_assistant_points_to_current_edge_guidance(self):
+        prompt = main.bloodhound_assistant()
+        assert "TrustedBy" not in prompt
+        assert "bloodhound://cypher/offensive-queries" in prompt
+        assert "bloodhound://cypher/reference" in prompt
+
+    def test_offensive_query_library_uses_current_edge_names(self):
+        text = main.offensive_query_library()
+        assert "TrustedBy" not in text
+        assert "SameForestTrust" in text
+        assert "GetChangesInFilteredSet" in text
+        assert "OwnsLimitedRights" in text
+        assert "WriteOwnerLimitedRights" in text
+        assert "ClaimSpecialIdentity" in text
+
+
 class TestCypherQuery:
     @patch("main.bloodhound_api")
     def test_run_success_with_nodes(self, api):

--- a/tests/test_main_mcp_tools.py
+++ b/tests/test_main_mcp_tools.py
@@ -26,7 +26,12 @@ project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
 import main
-from lib.bloodhound_api import BloodhoundAPIError, BloodhoundConnectionError
+from lib.bloodhound_api import (
+    BloodhoundAPI,
+    BloodhoundAPIError,
+    BloodhoundConnectionError,
+)
+from mcp.server.fastmcp import FastMCP
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +47,12 @@ GPO_ID = "5E6F7A8B-1234-5678-ABCD-1234567890AB"
 TEMPLATE_ID = "9C0D1E2F-1234-5678-ABCD-1234567890AB"
 CA_ID = "3A4B5C6D-1234-5678-ABCD-1234567890AB"
 QUERY_ID = "42"
+
+
+class TestRuntimeCompatibility:
+    def test_existing_fastmcp_import_and_eager_api_initialization(self):
+        assert isinstance(main.mcp, FastMCP)
+        assert isinstance(main.bloodhound_api, BloodhoundAPI)
 
 
 def make_api_error(status_code: int) -> BloodhoundAPIError:

--- a/uv.lock
+++ b/uv.lock
@@ -26,15 +26,6 @@ wheels = [
 ]
 
 [[package]]
-name = "argparse"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/argparse-1.4.0.tar.gz", hash = "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4", size = 70508 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/94/3af39d34be01a24a6e65433d19e107099374224905f1e0cc6bbe1fd22a2f/argparse-1.4.0-py2.py3-none-any.whl", hash = "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314", size = 23000 },
-]
-
-[[package]]
 name = "authlib"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -79,12 +70,9 @@ name = "bloodhound-mcp"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "argparse" },
-    { name = "dotenv" },
     { name = "fastmcp" },
-    { name = "logging" },
+    { name = "python-dotenv" },
     { name = "requests" },
-    { name = "typing" },
 ]
 
 [package.dev-dependencies]
@@ -99,12 +87,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "argparse", specifier = ">=1.4.0" },
-    { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "fastmcp", specifier = ">=0.4.1" },
-    { name = "logging", specifier = ">=0.4.9.6" },
-    { name = "requests", specifier = ">=2.32.3" },
-    { name = "typing", specifier = ">=3.10.0.0" },
+    { name = "fastmcp", specifier = "==2.9.2" },
+    { name = "python-dotenv", specifier = "==1.1.1" },
+    { name = "requests", specifier = "==2.32.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -341,17 +326,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.9.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dotenv" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892 },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -445,12 +419,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
 ]
-
-[[package]]
-name = "logging"
-version = "0.4.9.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/93/4b/979db9e44be09f71e85c9c8cfc42f258adfb7d93ce01deed2788b2948919/logging-0.4.9.6.tar.gz", hash = "sha256:26f6b50773f085042d301085bd1bf5d9f3735704db9f37c1ce6d8b85c38f2417", size = 96029 }
 
 [[package]]
 name = "markdown-it-py"
@@ -906,15 +874,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317 },
-]
-
-[[package]]
-name = "typing"
-version = "3.10.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/1b/835d4431805939d2996f8772aca1d2313a57e8860fec0e48e8e7dfe3a477/typing-3.10.0.0.tar.gz", hash = "sha256:13b4ad211f54ddbf93e5901a9967b1e07720c1d1b78d596ac6a439641aa1b130", size = 78962 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/5d/865e17349564eb1772688d8afc5e3081a5964c640d64d1d2880ebaed002d/typing-3.10.0.0-py3-none-any.whl", hash = "sha256:12fbdfbe7d6cca1a42e485229afcb0b0c8259258cfb919b8a5e2a5c953742f89", size = 26320 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -26,18 +26,6 @@ wheels = [
 ]
 
 [[package]]
-name = "authlib"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/9d/b1e08d36899c12c8b894a44a5583ee157789f26fc4b176f8e4b6217b56e1/authlib-1.6.0.tar.gz", hash = "sha256:4367d32031b7af175ad3a323d571dc7257b7099d55978087ceae4a0d88cd3210", size = 158371 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/29/587c189bbab1ccc8c86a03a5d0e13873df916380ef1be461ebe6acebf48d/authlib-1.6.0-py2.py3-none-any.whl", hash = "sha256:91685589498f79e8655e8a8947431ad6288831d643f11c55c2143ffcc738048d", size = 239981 },
-]
-
-[[package]]
 name = "black"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -70,7 +58,7 @@ name = "bloodhound-mcp"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "fastmcp" },
+    { name = "mcp" },
     { name = "python-dotenv" },
     { name = "requests" },
 ]
@@ -87,7 +75,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = "==2.9.2" },
+    { name = "mcp", specifier = "==1.9.4" },
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "requests", specifier = "==2.32.4" },
 ]
@@ -109,51 +97,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650 },
-]
-
-[[package]]
-name = "cffi"
-version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/f4/927e3a8899e52a27fa57a48607ff7dc91a9ebe97399b357b85a0c7892e00/cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401", size = 182264 },
-    { url = "https://files.pythonhosted.org/packages/6c/f5/6c3a8efe5f503175aaddcbea6ad0d2c96dad6f5abb205750d1b3df44ef29/cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf", size = 178651 },
-    { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259 },
-    { url = "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41", size = 469200 },
-    { url = "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1", size = 477235 },
-    { url = "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6", size = 459721 },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d", size = 467242 },
-    { url = "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6", size = 477999 },
-    { url = "https://files.pythonhosted.org/packages/44/74/f2a2460684a1a2d00ca799ad880d54652841a780c4c97b87754f660c7603/cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f", size = 454242 },
-    { url = "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b", size = 478604 },
-    { url = "https://files.pythonhosted.org/packages/34/33/e1b8a1ba29025adbdcda5fb3a36f94c03d771c1b7b12f726ff7fef2ebe36/cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655", size = 171727 },
-    { url = "https://files.pythonhosted.org/packages/3d/97/50228be003bb2802627d28ec0627837ac0bf35c90cf769812056f235b2d1/cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0", size = 181400 },
-    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178 },
-    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840 },
-    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803 },
-    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850 },
-    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729 },
-    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256 },
-    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424 },
-    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568 },
-    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736 },
-    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448 },
-    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976 },
-    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989 },
-    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802 },
-    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792 },
-    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893 },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810 },
-    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200 },
-    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447 },
-    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358 },
-    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
-    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475 },
-    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009 },
 ]
 
 [[package]]
@@ -285,78 +228,6 @@ toml = [
 ]
 
 [[package]]
-name = "cryptography"
-version = "45.0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/a2a376a8711c1e11708b9c9972e0c3223f5fc682552c82d8db844393d6ce/cryptography-45.0.4.tar.gz", hash = "sha256:7405ade85c83c37682c8fe65554759800a4a8c54b2d96e0f8ad114d31b808d57", size = 744890 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/1c/92637793de053832523b410dbe016d3f5c11b41d0cf6eef8787aabb51d41/cryptography-45.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:425a9a6ac2823ee6e46a76a21a4e8342d8fa5c01e08b823c1f19a8b74f096069", size = 7055712 },
-    { url = "https://files.pythonhosted.org/packages/ba/14/93b69f2af9ba832ad6618a03f8a034a5851dc9a3314336a3d71c252467e1/cryptography-45.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:680806cf63baa0039b920f4976f5f31b10e772de42f16310a6839d9f21a26b0d", size = 4205335 },
-    { url = "https://files.pythonhosted.org/packages/67/30/fae1000228634bf0b647fca80403db5ca9e3933b91dd060570689f0bd0f7/cryptography-45.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ca0f52170e821bc8da6fc0cc565b7bb8ff8d90d36b5e9fdd68e8a86bdf72036", size = 4431487 },
-    { url = "https://files.pythonhosted.org/packages/6d/5a/7dffcf8cdf0cb3c2430de7404b327e3db64735747d641fc492539978caeb/cryptography-45.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f3fe7a5ae34d5a414957cc7f457e2b92076e72938423ac64d215722f6cf49a9e", size = 4208922 },
-    { url = "https://files.pythonhosted.org/packages/c6/f3/528729726eb6c3060fa3637253430547fbaaea95ab0535ea41baa4a6fbd8/cryptography-45.0.4-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:25eb4d4d3e54595dc8adebc6bbd5623588991d86591a78c2548ffb64797341e2", size = 3900433 },
-    { url = "https://files.pythonhosted.org/packages/d9/4a/67ba2e40f619e04d83c32f7e1d484c1538c0800a17c56a22ff07d092ccc1/cryptography-45.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ce1678a2ccbe696cf3af15a75bb72ee008d7ff183c9228592ede9db467e64f1b", size = 4464163 },
-    { url = "https://files.pythonhosted.org/packages/7e/9a/b4d5aa83661483ac372464809c4b49b5022dbfe36b12fe9e323ca8512420/cryptography-45.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:49fe9155ab32721b9122975e168a6760d8ce4cffe423bcd7ca269ba41b5dfac1", size = 4208687 },
-    { url = "https://files.pythonhosted.org/packages/db/b7/a84bdcd19d9c02ec5807f2ec2d1456fd8451592c5ee353816c09250e3561/cryptography-45.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2882338b2a6e0bd337052e8b9007ced85c637da19ef9ecaf437744495c8c2999", size = 4463623 },
-    { url = "https://files.pythonhosted.org/packages/d8/84/69707d502d4d905021cac3fb59a316344e9f078b1da7fb43ecde5e10840a/cryptography-45.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:23b9c3ea30c3ed4db59e7b9619272e94891f8a3a5591d0b656a7582631ccf750", size = 4332447 },
-    { url = "https://files.pythonhosted.org/packages/f3/ee/d4f2ab688e057e90ded24384e34838086a9b09963389a5ba6854b5876598/cryptography-45.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0a97c927497e3bc36b33987abb99bf17a9a175a19af38a892dc4bbb844d7ee2", size = 4572830 },
-    { url = "https://files.pythonhosted.org/packages/70/d4/994773a261d7ff98034f72c0e8251fe2755eac45e2265db4c866c1c6829c/cryptography-45.0.4-cp311-abi3-win32.whl", hash = "sha256:e00a6c10a5c53979d6242f123c0a97cff9f3abed7f064fc412c36dc521b5f257", size = 2932769 },
-    { url = "https://files.pythonhosted.org/packages/5a/42/c80bd0b67e9b769b364963b5252b17778a397cefdd36fa9aa4a5f34c599a/cryptography-45.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:817ee05c6c9f7a69a16200f0c90ab26d23a87701e2a284bd15156783e46dbcc8", size = 3410441 },
-    { url = "https://files.pythonhosted.org/packages/ce/0b/2488c89f3a30bc821c9d96eeacfcab6ff3accc08a9601ba03339c0fd05e5/cryptography-45.0.4-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:964bcc28d867e0f5491a564b7debb3ffdd8717928d315d12e0d7defa9e43b723", size = 7031836 },
-    { url = "https://files.pythonhosted.org/packages/fe/51/8c584ed426093aac257462ae62d26ad61ef1cbf5b58d8b67e6e13c39960e/cryptography-45.0.4-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6a5bf57554e80f75a7db3d4b1dacaa2764611ae166ab42ea9a72bcdb5d577637", size = 4195746 },
-    { url = "https://files.pythonhosted.org/packages/5c/7d/4b0ca4d7af95a704eef2f8f80a8199ed236aaf185d55385ae1d1610c03c2/cryptography-45.0.4-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:46cf7088bf91bdc9b26f9c55636492c1cce3e7aaf8041bbf0243f5e5325cfb2d", size = 4424456 },
-    { url = "https://files.pythonhosted.org/packages/1d/45/5fabacbc6e76ff056f84d9f60eeac18819badf0cefc1b6612ee03d4ab678/cryptography-45.0.4-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7bedbe4cc930fa4b100fc845ea1ea5788fcd7ae9562e669989c11618ae8d76ee", size = 4198495 },
-    { url = "https://files.pythonhosted.org/packages/55/b7/ffc9945b290eb0a5d4dab9b7636706e3b5b92f14ee5d9d4449409d010d54/cryptography-45.0.4-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:eaa3e28ea2235b33220b949c5a0d6cf79baa80eab2eb5607ca8ab7525331b9ff", size = 3885540 },
-    { url = "https://files.pythonhosted.org/packages/7f/e3/57b010282346980475e77d414080acdcb3dab9a0be63071efc2041a2c6bd/cryptography-45.0.4-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7ef2dde4fa9408475038fc9aadfc1fb2676b174e68356359632e980c661ec8f6", size = 4452052 },
-    { url = "https://files.pythonhosted.org/packages/37/e6/ddc4ac2558bf2ef517a358df26f45bc774a99bf4653e7ee34b5e749c03e3/cryptography-45.0.4-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6a3511ae33f09094185d111160fd192c67aa0a2a8d19b54d36e4c78f651dc5ad", size = 4198024 },
-    { url = "https://files.pythonhosted.org/packages/3a/c0/85fa358ddb063ec588aed4a6ea1df57dc3e3bc1712d87c8fa162d02a65fc/cryptography-45.0.4-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:06509dc70dd71fa56eaa138336244e2fbaf2ac164fc9b5e66828fccfd2b680d6", size = 4451442 },
-    { url = "https://files.pythonhosted.org/packages/33/67/362d6ec1492596e73da24e669a7fbbaeb1c428d6bf49a29f7a12acffd5dc/cryptography-45.0.4-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5f31e6b0a5a253f6aa49be67279be4a7e5a4ef259a9f33c69f7d1b1191939872", size = 4325038 },
-    { url = "https://files.pythonhosted.org/packages/53/75/82a14bf047a96a1b13ebb47fb9811c4f73096cfa2e2b17c86879687f9027/cryptography-45.0.4-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:944e9ccf67a9594137f942d5b52c8d238b1b4e46c7a0c2891b7ae6e01e7c80a4", size = 4560964 },
-    { url = "https://files.pythonhosted.org/packages/cd/37/1a3cba4c5a468ebf9b95523a5ef5651244693dc712001e276682c278fc00/cryptography-45.0.4-cp37-abi3-win32.whl", hash = "sha256:c22fe01e53dc65edd1945a2e6f0015e887f84ced233acecb64b4daadb32f5c97", size = 2924557 },
-    { url = "https://files.pythonhosted.org/packages/2a/4b/3256759723b7e66380397d958ca07c59cfc3fb5c794fb5516758afd05d41/cryptography-45.0.4-cp37-abi3-win_amd64.whl", hash = "sha256:627ba1bc94f6adf0b0a2e35d87020285ead22d9f648c7e75bb64f367375f3b22", size = 3395508 },
-    { url = "https://files.pythonhosted.org/packages/ea/ba/cf442ae99ef363855ed84b39e0fb3c106ac66b7a7703f3c9c9cfe05412cb/cryptography-45.0.4-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4828190fb6c4bcb6ebc6331f01fe66ae838bb3bd58e753b59d4b22eb444b996c", size = 3590512 },
-    { url = "https://files.pythonhosted.org/packages/28/9a/a7d5bb87d149eb99a5abdc69a41e4e47b8001d767e5f403f78bfaafc7aa7/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:03dbff8411206713185b8cebe31bc5c0eb544799a50c09035733716b386e61a4", size = 4146899 },
-    { url = "https://files.pythonhosted.org/packages/17/11/9361c2c71c42cc5c465cf294c8030e72fb0c87752bacbd7a3675245e3db3/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:51dfbd4d26172d31150d84c19bbe06c68ea4b7f11bbc7b3a5e146b367c311349", size = 4388900 },
-    { url = "https://files.pythonhosted.org/packages/c0/76/f95b83359012ee0e670da3e41c164a0c256aeedd81886f878911581d852f/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:0339a692de47084969500ee455e42c58e449461e0ec845a34a6a9b9bf7df7fb8", size = 4146422 },
-    { url = "https://files.pythonhosted.org/packages/09/ad/5429fcc4def93e577a5407988f89cf15305e64920203d4ac14601a9dc876/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:0cf13c77d710131d33e63626bd55ae7c0efb701ebdc2b3a7952b9b23a0412862", size = 4388475 },
-    { url = "https://files.pythonhosted.org/packages/99/49/0ab9774f64555a1b50102757811508f5ace451cf5dc0a2d074a4b9deca6a/cryptography-45.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bbc505d1dc469ac12a0a064214879eac6294038d6b24ae9f71faae1448a9608d", size = 3337594 },
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674 },
-]
-
-[[package]]
-name = "fastmcp"
-version = "2.9.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "authlib" },
-    { name = "exceptiongroup" },
-    { name = "httpx" },
-    { name = "mcp" },
-    { name = "openapi-pydantic" },
-    { name = "python-dotenv" },
-    { name = "rich" },
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/68/17/d2b5981180717e6e689d0aaa6215d1ddcec6cb065c6f6b45c471ab7d2edb/fastmcp-2.9.2.tar.gz", hash = "sha256:c000eb0a2d50afcc7d26be4c867abf5c995ca0e0119f17417d50f61e2e17347c", size = 2663824 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/60/223e1975e65ed7c6cead0fda947d4cdb4f7ee5ec60a7c8ea3b3787868f67/fastmcp-2.9.2-py3-none-any.whl", hash = "sha256:3626a3d9b1fa6325756273b6d1fe1ec610baafec957ac22f7aa1dc17c1db8b93", size = 162690 },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -421,18 +292,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
-]
-
-[[package]]
 name = "mcp"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -453,33 +312,12 @@ wheels = [
 ]
 
 [[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
-]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
-]
-
-[[package]]
-name = "openapi-pydantic"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381 },
 ]
 
 [[package]]
@@ -516,15 +354,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
-]
-
-[[package]]
-name = "pycparser"
-version = "2.22"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552 },
 ]
 
 [[package]]
@@ -767,28 +596,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
-]
-
-[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -859,21 +666,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
-]
-
-[[package]]
-name = "typer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- audit BloodHound relationships against CE 9.1.0 and correct deprecated, split, missing, directional, and pathfinding edge guidance
- preserve the current stdio entrypoint, eager API initialization, MCP surface, `.env` loading, and secure HTTPS defaults
- remove obsolete stdlib-shadowing dependencies and the unused standalone FastMCP distribution
- add an opt-in `BLOODHOUND_VERIFY_TLS=false` setting for trusted self-signed lab deployments

## Compatibility

Existing users do not need to change configuration. When the new TLS setting is absent, requests still omit the `verify` keyword and use Requests' secure default. The server continues to import `FastMCP` from `mcp.server.fastmcp`, initialize `BloodhoundAPI` eagerly, and run stdio through `mcp.run()`.

The useful dependency-cleanup and self-signed TLS ideas from #20 and #21 were reimplemented without importing contributor commit ancestry. The original changes could not be merged directly because they changed default initialization/framework behavior, used insecure or globally suppressed TLS handling, had precedence defects, or lacked regression coverage.

## Security Review

- all five commits are SSH-signed and have detailed Git notes
- lockfile sources are limited to PyPI plus the local project; retained artifacts keep their existing hashes
- no VCS, path, alternate-index, workflow, hook, build-script, or install-script surface was added
- removed `argparse`, `logging`, `typing`, the `dotenv` shim, and the unused `fastmcp` distribution plus 11 orphan transitive packages
- TLS verification remains enabled by default; disabling it is explicit, scoped to this client, and logs a warning
- current `mcp==1.9.4` has a published HTTP transport advisory, but this repository's unchanged default transport is stdio, which the advisory explicitly excludes; upgrading the MCP runtime is intentionally deferred because it would change the compatibility baseline

## Validation

- `uv run pytest tests/test_main_mcp_tools.py tests/test_bloodhound_api.py tests/test_bloodhound_http.py -q`: 344 passed
- `uv run pytest -q`: 359 passed, 11 live integration tests skipped
- `uv lock --check`
- `git diff --check origin/master...HEAD`
- independent read-only code/security review: no actionable findings
- confirmed neither #20 nor #21 is an ancestor of this branch

No BloodHound uploads, deletions, configuration changes, or other live writes were performed.
