### PR TITLE
Validate BloodHound credentials at MCP startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ BLOODHOUND_TOKEN_ID=your-token-id
 BLOODHOUND_TOKEN_KEY=your-token-key
 ```
 
+At startup, the MCP server makes a signed, read-only request to
+`/api/v2/self`. Invalid credentials, connectivity failures, and TLS failures
+stop the server before it accepts MCP tool calls. The startup request times out
+after 10 seconds.
+
 The server defaults to `https` on port `443`. Override if needed:
 
 ```env

--- a/lib/bloodhound_api.py
+++ b/lib/bloodhound_api.py
@@ -41,10 +41,10 @@ class BloodhoundConnectionError(BloodhoundError):
 class BloodhoundAPIError(BloodhoundError):
     """Custom exception for BloodHound API errors"""
 
-    def __init__(self, message: str, response: requests.Response):
+    def __init__(self, message: str, response: Optional[requests.Response]):
         super().__init__(message)
         self.response = response
-        self.status_code = response.status_code if response else None
+        self.status_code = response.status_code if response is not None else None
 
 
 class BloodhoundBaseClient:
@@ -132,6 +132,7 @@ class BloodhoundBaseClient:
         body: Optional[bytes] = None,
         content_type: str = "application/json",
         extra_headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[float] = None,
     ) -> requests.Response:
         """
         Make a signed request to the BloodHound API
@@ -141,6 +142,8 @@ class BloodhoundBaseClient:
             uri: Request URI
             body: Optional request body
             content_type: Content-Type header value (default: application/json)
+            extra_headers: Optional additional HTTP headers
+            timeout: Optional request timeout in seconds
 
         Returns:
             Response from the API
@@ -185,7 +188,13 @@ class BloodhoundBaseClient:
             }
             if not self.verify_tls:
                 request_kwargs["verify"] = False
+            if timeout is not None:
+                request_kwargs["timeout"] = timeout
             return requests.request(**request_kwargs)
+        except requests.exceptions.Timeout as e:
+            raise BloodhoundConnectionError(
+                f"Timed out connecting to BloodHound API: {e}"
+            )
         except requests.exceptions.ConnectionError as e:
             raise BloodhoundConnectionError(f"Failed to connect to BloodHound API: {e}")
 
@@ -195,6 +204,7 @@ class BloodhoundBaseClient:
         uri: str,
         params: Optional[Dict[str, Any]] = None,
         data: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
         Make an API request and return the parsed JSON response
@@ -204,6 +214,7 @@ class BloodhoundBaseClient:
             uri: Request URI
             params: Optional query parameters
             data: Optional request body data (will be JSON encoded)
+            timeout: Optional request timeout in seconds
 
         Returns:
             Parsed JSON response
@@ -218,7 +229,7 @@ class BloodhoundBaseClient:
             body = json.dumps(data).encode("utf8")
 
         # Make the request
-        response = self._request(method, uri, body)
+        response = self._request(method, uri, body, timeout=timeout)
 
         # Handle response
         try:
@@ -519,6 +530,18 @@ class BloodhoundAPI:
         self.opengraph_extensions = OpenGraphExtensionsClient(self.base_client)
         self.asset_groups = AssetGroupsClient(self.base_client)
         self.file_upload = FileUploadClient(self.base_client)
+
+    STARTUP_TIMEOUT_SECONDS = 10
+
+    def validate_credentials(self) -> None:
+        """Validate configured credentials against the authenticated self endpoint.
+
+        Unlike the legacy connection helpers below, this method deliberately lets
+        connection and API errors propagate so callers can fail closed.
+        """
+        self.base_client.request(
+            "GET", "/api/v2/self", timeout=self.STARTUP_TIMEOUT_SECONDS
+        )
 
     def test_connection(self) -> Dict[str, Any]:
         """

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ import binascii
 import json
 import logging
 import re
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
@@ -42,9 +44,32 @@ AGGREGATION_PATTERN = re.compile(
 # Load environment variables
 load_dotenv()
 
-# Initialize the MCP server and Bloodhound API client
-mcp = FastMCP("bloodhound_mcp")
+# Initialize the BloodHound API client before configuring the MCP lifespan.
 bloodhound_api = BloodhoundAPI()
+
+
+@asynccontextmanager
+async def _bloodhound_lifespan(_: FastMCP) -> AsyncIterator[None]:
+    """Validate BloodHound credentials before accepting MCP requests."""
+    try:
+        bloodhound_api.validate_credentials()
+    except BloodhoundAPIError as e:
+        logger.error(
+            "BloodHound credential preflight failed (HTTP %s)", e.status_code
+        )
+        raise
+    except BloodhoundConnectionError:
+        logger.error("BloodHound credential preflight failed: unable to connect")
+        raise
+    except Exception:
+        logger.error("BloodHound credential preflight failed: unexpected error")
+        raise
+
+    logger.info("BloodHound credential preflight passed")
+    yield
+
+
+mcp = FastMCP("bloodhound_mcp", lifespan=_bloodhound_lifespan)
 
 
 # Helper function

--- a/tests/test_bloodhound_api.py
+++ b/tests/test_bloodhound_api.py
@@ -57,6 +57,16 @@ class TestExceptions:
         assert error.response is None
         assert error.status_code is None
 
+    def test_bloodhound_api_error_keeps_status_from_falsey_error_response(self):
+        """HTTP error responses still expose their status code."""
+        response = requests.Response()
+        response.status_code = 401
+
+        assert not response
+
+        error = BloodhoundAPIError("Unauthorized", response)
+        assert error.status_code == 401
+
 
 class TestBloodhoundBaseClient:
     """Test the BloodhoundBaseClient class"""
@@ -229,6 +239,21 @@ class TestBloodhoundBaseClient:
             client._request("GET", "/api/v2/test")
         
         assert "Failed to connect to BloodHound API" in str(exc_info.value)
+
+    @patch("requests.request")
+    def test_request_timeout_is_bounded_and_wrapped(self, mock_request):
+        """A configured timeout is forwarded and reported as a connection error."""
+        mock_request.side_effect = requests.exceptions.Timeout("Request timed out")
+
+        client = BloodhoundBaseClient(
+            domain="test.local", token_id="test_id", token_key="test_key"
+        )
+
+        with pytest.raises(BloodhoundConnectionError) as exc_info:
+            client._request("GET", "/api/v2/self", timeout=10)
+
+        assert "Timed out connecting to BloodHound API" in str(exc_info.value)
+        assert mock_request.call_args.kwargs["timeout"] == 10
 
     @patch('requests.request')
     def test_request_with_params_and_data(self, mock_request):
@@ -406,6 +431,40 @@ class TestBloodhoundAPI:
         
         result = api.test_connection()
         assert result is None
+
+    @patch.object(BloodhoundBaseClient, "request")
+    def test_validate_credentials_success(self, mock_request):
+        """Credential validation uses the authenticated self endpoint."""
+        mock_request.return_value = {"data": {"id": "123"}}
+
+        api = BloodhoundAPI(
+            domain="test.local",
+            token_id="test_id",
+            token_key="test_key",
+        )
+
+        assert api.validate_credentials() is None
+        mock_request.assert_called_once_with(
+            "GET", "/api/v2/self", timeout=api.STARTUP_TIMEOUT_SECONDS
+        )
+
+    @patch.object(BloodhoundBaseClient, "request")
+    def test_validate_credentials_propagates_failure(self, mock_request):
+        """Credential validation fails closed instead of swallowing API errors."""
+        response = Mock(status_code=401)
+        error = BloodhoundAPIError("Unauthorized", response)
+        mock_request.side_effect = error
+
+        api = BloodhoundAPI(
+            domain="test.local",
+            token_id="test_id",
+            token_key="test_key",
+        )
+
+        with pytest.raises(BloodhoundAPIError) as exc_info:
+            api.validate_credentials()
+
+        assert exc_info.value is error
 
     @patch.object(BloodhoundBaseClient, 'request')
     def test_get_self_info_success(self, mock_request):

--- a/tests/test_main_mcp_tools.py
+++ b/tests/test_main_mcp_tools.py
@@ -15,6 +15,7 @@ Helper covered:
     _handle_tool_call (dispatch, unknown info_type, error propagation)
 """
 
+import asyncio
 import base64
 import json
 import sys
@@ -55,6 +56,9 @@ class TestRuntimeCompatibility:
         assert isinstance(main.mcp, FastMCP)
         assert isinstance(main.bloodhound_api, BloodhoundAPI)
 
+    def test_fastmcp_uses_credential_preflight_lifespan(self):
+        assert main.mcp.settings.lifespan is main._bloodhound_lifespan
+
 
 def make_api_error(status_code: int) -> BloodhoundAPIError:
     response = MagicMock()
@@ -87,6 +91,41 @@ def make_api_error_with_body(
     error = BloodhoundAPIError(f"HTTP {status_code}", response)
     error.status_code = status_code
     return error
+
+
+class TestStartupCredentialPreflight:
+    @staticmethod
+    async def _run_lifespan():
+        async with main._bloodhound_lifespan(main.mcp):
+            pass
+
+    def test_validates_credentials_before_startup(self):
+        with patch.object(
+            main.bloodhound_api, "validate_credentials"
+        ) as validate_credentials:
+            asyncio.run(self._run_lifespan())
+
+        validate_credentials.assert_called_once_with()
+
+    def test_authentication_failure_aborts_startup(self):
+        error = make_api_error(401)
+        with patch.object(
+            main.bloodhound_api, "validate_credentials", side_effect=error
+        ):
+            with pytest.raises(BloodhoundAPIError) as exc_info:
+                asyncio.run(self._run_lifespan())
+
+        assert exc_info.value is error
+
+    def test_connection_failure_aborts_startup(self):
+        error = BloodhoundConnectionError("unreachable")
+        with patch.object(
+            main.bloodhound_api, "validate_credentials", side_effect=error
+        ):
+            with pytest.raises(BloodhoundConnectionError) as exc_info:
+                asyncio.run(self._run_lifespan())
+
+        assert exc_info.value is error
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate configured BloodHound credentials through the read-only `/api/v2/self` endpoint during FastMCP startup
- fail closed on authentication, connectivity, TLS, and 10-second timeout failures
- preserve HTTP error status codes and document the startup gate

## Validation
- `uv run pytest -q` — 380 passed, 11 skipped
- `uv lock --check` — passed
- staged Gitleaks scan — clean
- live read-only FastMCP startup preflight — passed
- independent code review — no findings, merge-ready